### PR TITLE
Build environment section in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ and talk to us on Matrix:
 Discuss with Developers:
 
   Discourse: https://discourse.mozilla-community.org/c/b2g-os-participation
+  
+# Build environment
+
+As of today, only Linux hosts are supported.
+
+You can read more about it on the following page :
+
+  https://source.android.com/setup/build/initializing
 
 # Building and running the android-10 emulator x86_64
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ You can read more about it on the following page :
 
 # Building and running the android-10 emulator x86_64
 
-_Warning: as of today, Mac OS X is not supported_
-
 1. Fetch the code: `REPO_INIT_FLAGS="--depth=1" ./config.sh emulator-10-x86_64`
 2. Setup your environment to fetch the custom NDK: `export LOCAL_NDK_BASE_URL='ftp://ftp.kaiostech.com/ndk/android-ndk'`
 3. Install Gecko dependencies: `cd gecko && ./mach bootstrap`, choose option 1 (Boot2Gecko).

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Discuss with Developers:
 
 # Building and running the android-10 emulator x86_64
 
+_Warning: as of today, Mac OS X is not supported_
+
 1. Fetch the code: `REPO_INIT_FLAGS="--depth=1" ./config.sh emulator-10-x86_64`
 2. Setup your environment to fetch the custom NDK: `export LOCAL_NDK_BASE_URL='ftp://ftp.kaiostech.com/ndk/android-ndk'`
 3. Install Gecko dependencies: `cd gecko && ./mach bootstrap`, choose option 1 (Boot2Gecko).


### PR DESCRIPTION
> Important: Platform development on MacOS isn't supported as of June 22, 2021.

https://source.android.com/setup/build/initializing
